### PR TITLE
Add li_delete_image script

### DIFF
--- a/li_delete_image
+++ b/li_delete_image
@@ -1,0 +1,36 @@
+#!/usr/bin/env python
+# Copyright (C) 2018 Layered Insight - All Rights Reserved
+# Unauthorized copying of this file, via any medium is strictly prohibited
+# Proprietary and confidential
+
+from __future__ import print_function
+import argparse
+import sys
+import layint_scan_api
+from layint_scan_api.rest import ApiException
+from vyper import v
+from li_utils.envtools import env_setup
+
+# Parse CLI
+parser = argparse.ArgumentParser()
+parser.add_argument("-v", "--verbose", help="Verbose logging", action="store_true")
+parser.add_argument("--id", help="ID of image to delete", required=True)
+args = parser.parse_args()
+
+env_setup()
+
+layint_scan_api.configuration.api_key['Authorization'] = v.get("api_key")
+
+images_api = layint_scan_api.ImagesApi()
+images_api.api_client.host = v.get("api_host")
+
+if args.verbose:
+    print("Deleting image %s for scan API host %s..." % (args.id, v.get("api_host")))
+try:
+    image = images_api.delete_image(args.id)
+except ApiException as e:
+    print("Exception when calling ImagesApi->delete_image: %s\n" % e)
+    sys.exit(1)
+
+if args.verbose:
+    print("Image %s deleted successfully." % (args.id))


### PR DESCRIPTION
### Add li_delete_image script to delete image from scan mongodb

**Usage:**
```
$ ./li_delete_image --id IM152b239b79949d8b89dbee0a382ea0367f4fd3e07a361fe6 --verbose
Deleting image IM152b239b79949d8b89dbee0a382ea0367f4fd3e07a361fe6 for scan API host http://localhost:3000/V0.0.1...
Image IM152b239b79949d8b89dbee0a382ea0367f4fd3e07a361fe6 deleted successfully.
```
