### PR TITLE
add Registry options: insecure-registry, no-tls-verify

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,6 @@ COPY * /layint/
 COPY li_utils/* /layint/li_utils/
 RUN apk update && \
     apk add gcc musl-dev && \
-    pip install layint_scan_api && \
     pip install -r /layint/requirements.txt
 
 ### Set environment variables for your installation

--- a/li_add_registry
+++ b/li_add_registry
@@ -20,6 +20,8 @@ parser.add_argument("--url", help="URL of registry to add", required=True)
 parser.add_argument("--type", help="Type of registry to add. docker.io is default", required=True, choices=["dtr", "docker.io", "ecr", "private"], default="docker.io")
 parser.add_argument("--username", help="Username to authenticate to registry with", required=False)
 parser.add_argument("--password", help="Password to authenticate to registry with", required=False)
+parser.add_argument("--no-tls-verify", help="Disables server certificate verification", action='store_true', default=None)
+parser.add_argument("--insecure-registry", help="Allows HTTP protocol requests when set", action='store_true', default=None)
 parser.add_argument("--prompt-password", help="Prompt for Password to authenticate private registry", action='store_true', default=None)
 args = parser.parse_args()
 
@@ -32,6 +34,7 @@ registry_api.api_client.host = v.get("api_host")
 registry = layint_scan_api.Registry(name=args.name)
 registry.type = args.type
 registry.url = args.url
+registry.tls_verify = True
 
 if registry.url.startswith("http://") or registry.url.startswith("https://"):
     print("ERROR: URL should not start with http:// or https://")
@@ -39,6 +42,12 @@ if registry.url.startswith("http://") or registry.url.startswith("https://"):
 
 if args.username:
     registry.username = args.username
+
+if args.no_tls_verify is not None:
+    registry.tls_verify = False
+
+if args.insecure_registry is not None:
+    registry.insecure_registry = args.insecure_registry
 
 if args.prompt_password is not None:
     registry.password = getpass()

--- a/li_add_registry
+++ b/li_add_registry
@@ -35,6 +35,7 @@ registry = layint_scan_api.Registry(name=args.name)
 registry.type = args.type
 registry.url = args.url
 registry.tls_verify = True
+registry.insecure_registry = False
 
 if registry.url.startswith("http://") or registry.url.startswith("https://"):
     print("ERROR: URL should not start with http:// or https://")
@@ -47,7 +48,7 @@ if args.no_tls_verify is not None:
     registry.tls_verify = False
 
 if args.insecure_registry is not None:
-    registry.insecure_registry = args.insecure_registry
+    registry.insecure_registry = True
 
 if args.prompt_password is not None:
     registry.password = getpass()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
-vyper
+vyper-config >= 0.2.1
+layint-scan-api >= 0.9.6


### PR DESCRIPTION

build depends on pypi distribution of layint-scan-api 0.9.6

Also closes #13  with update to  layint-scan-api 0.9.6